### PR TITLE
Improve daily rotation handling

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,8 +58,4 @@
   tags:
     - configuration
 
-- name: Symlink for hourly rotation
-  file:
-    path: "/etc/cron.hourly/logrotate"
-    src: "/etc/cron.daily/logrotate"
-    state: "{{ 'link' if logrotate_use_hourly_rotation else 'absent' }}"
+- import_tasks: rotation.yml

--- a/tasks/rotation.yml
+++ b/tasks/rotation.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Check logrotate cron file presence
+  stat:
+    path: >
+      /etc/cron.{{ logrotate_use_hourly_rotation | ternary('daily', 'hourly') }}
+      /logrotate
+  check_mode: false
+  changed_when: false
+  register: old_rotation_file
+
+- name: Copy logrotate file to new cron rotation directory
+  copy:
+    path: "{{ old_rotation_file.path }}"
+    src: >
+      /etc/cron.{{ logrotate_use_hourly_rotation | ternary('hourly', 'daily') }}
+      /logrotate
+  when: old_rotation_file.stat.exists
+
+- name: Remove old logrotate file
+  file:
+    path: "{{ old_rotation_file.path }}"
+    state: absent
+  when: old_rotation_file.stat.exists
+
+- name: Check systemd timer file presence
+  stat:
+    path: /usr/lib/systemd/system/logrotate.timer
+  check_mode: false
+  changed_when: false
+  register: logrotate_timer_file
+
+- name: Set systemd logrotate timer rotation frequency
+  ini_file:
+    path: logrotate_timer_file.stat.path
+    section: Timer
+    option: "{{ logrotate_use_hourly_rotation | ternary('hourly', 'daily') }}"
+  when: logrotate_timer_file.stat.exists


### PR DESCRIPTION
~Why symlinking `/etc/cron.hourly/logrotate` to `/etc/cron.daily/logrotate`?  What about `weekly` and `monthly`?~

~I removed this logic:~
~- We can use the `hourly` logrotate option instead.~
- Fixes the following deprecation warning: `[WARNING]: The src option requires state to be 'link' or 'hard'.  This will become an error in Ansible 2.10`

Fixes https://github.com/arillso/ansible.logrotate/issues/14