### PR TITLE
Move application configuration to dedicated tasks file

### DIFF
--- a/tasks/configure_application.yml
+++ b/tasks/configure_application.yml
@@ -1,0 +1,13 @@
+---
+- name: 'create logrotate application configuration files'
+  become: true
+  template:
+    src: 'etc/logrotate.d/application.j2'
+    dest: '/etc/logrotate.d/{{ item.name }}'
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - '{{ logrotate_applications }}'
+  tags:
+    - configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,18 +44,8 @@
     - configuration
   when: logrotate_global_config | bool
 
-- name: create logrotate application configuration files
-  become: true
-  template:
-    src: 'etc/logrotate.d/application.j2'
-    dest: '/etc/logrotate.d/{{ item.name }}'
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - '{{ logrotate_applications }}'
-  tags:
-    - configuration
+- name: 'create logrotate application configuration files'
+  import_tasks: configure_application.yml
 
 - name: symlink for hourly rotation
   file:


### PR DESCRIPTION
This allows to use the tasks_from option of the import_role module.
This permits to install and configure logrotate basics in one playbook, and
to configure application specifics in another application specific playbook
with something like:

```
- name: "Configure log rotation."
  import_role:
    name: ansible.logrotate
    tasks_from: configure_application
  become: True
  vars:
    logrotate_applications: "{{ redis_logrotate_configurations }}"
  when: redis_logrotate_configurations is defined
```
for instance.