### PR TITLE
Fix for state warning in ansible 2.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+- Added role requirements for gathered facts.
+
 ## 1.5.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installs and configures logrotate
 
 ## Requirements
 
-None
+* The role requires `gathered_facts: true` to be set.
 
 ## Role Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,4 +62,4 @@
   file:
     path: "/etc/cron.hourly/logrotate"
     src: "/etc/cron.daily/logrotate"
-    state: "{{ 'link' if logrotate_use_hourly_rotation else 'absent' }}"
+    state: "{{ 'link' if logrotate_use_hourly_rotation is defined | default('absent') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for arillso.logrotate
-
-- name: add OS specific variables
+- name: Main | Add OS specific variables
   include_vars: '{{ loop_vars }}'
   with_first_found:
     - files:
@@ -23,7 +22,7 @@
     - configuration
     - packages
 
-- name: 'install logrotate packages'
+- name: Main | Manage logrotate packages
   become: true
   package:
     name: '{{ logrotate_package }}'
@@ -34,7 +33,7 @@
   tags:
     - packages
 
-- name: 'create logrotate configuration file'
+- name: Main | Create logrotate configuration file
   become: true
   template:
     src: 'etc/logrotate.conf.j2'
@@ -45,7 +44,7 @@
   tags:
     - configuration
 
-- name: 'create logrotate application configuration files'
+- name: Main | Create logrotate application configuration files
   become: true
   template:
     src: 'etc/logrotate.d/application.j2'
@@ -58,8 +57,8 @@
   tags:
     - configuration
 
-- name: Symlink for hourly rotation
-  file:
+- name: Main | Symlink for hourly rotation
+  ansible.builtin.file:
     path: "/etc/cron.hourly/logrotate"
     src: "/etc/cron.daily/logrotate"
     state: "{{ 'link' if logrotate_use_hourly_rotation is defined | default('absent') }}"


### PR DESCRIPTION
This change fixes the warning in ansible 2.6.5 regarding the state parameter in the module `file`.

```
TASK [ansible_role_logrotate : Symlink for hourly rotation] ********************
 [WARNING]: The src option requires state to be 'link' or 'hard'.  This will
become an error in Ansible 2.10
```