### PR TITLE
allow skipping global configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,8 @@ logrotate_btmp:
     - create 0660 root utmp
     - rotate 1
 
+logrotate_global_config: True
+
 # More log files can be added that will log rotate.
 # An example of multiple log rotate applications with available settings:
 # logrotate_applications:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,7 @@
     mode: 0644
   tags:
     - configuration
+  when: logrotate_global_config | bool
 
 - name: 'create logrotate application configuration files'
   become: true


### PR DESCRIPTION
Allows skipping global logrotate configuration in /etc/logrotate.conf