### PR TITLE
[BUGFIX] Remove symlink when var gets changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,3 +64,9 @@
     mode: 0644
     state: link
   when: logrotate_use_hourly_rotation | bool
+
+- name: Remove symlink for hourly rotation
+  file:
+    path: "/etc/cron.hourly/logrotate"
+    state: absent
+  when: not logrotate_use_hourly_rotation | bool


### PR DESCRIPTION
Use case:
1. Set `logrotate_use_hourly_rotation` to true and run role
2. Symlink `/etc/cron.hourly/logrotate` gets created
3. Now set `logrotate_use_hourly_rotation` to false again
4. Symlink `/etc/cron.hourly/logrotate` does not get removed