### PR TITLE
Change default "item" in with_items with unique name to avoid clashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - MOLECULE_DISTRO: debian10
 
 install:
-  - pip install molecule yamllint ansible-lint docker
+  - pip install molecule[docker] yamllint ansible-lint docker
 
 script:
   - molecule test

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,12 +48,13 @@
   become: true
   template:
     src: 'etc/logrotate.d/application.j2'
-    dest: '/etc/logrotate.d/{{ item.name }}'
+    dest: '/etc/logrotate.d/{{ logrotate_applications_item.name }}'
     owner: root
     group: root
     mode: 0644
-  with_items:
-    - '{{ logrotate_applications }}'
+  loop: '{{ logrotate_applications }}'
+  loop_control:
+    loop_var: logrotate_applications_item
   tags:
     - configuration
 

--- a/templates/etc/logrotate.d/application.j2
+++ b/templates/etc/logrotate.d/application.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 
-{% for definition in item.definitions %}
+{% for definition in logrotate_applications_item.definitions %}
 {{ definition.logs | join(" ") }} {
 {% for option in definition.options %}
     {{ option }}


### PR DESCRIPTION
This helps in avoiding "item" name clashes when using this role inside another one that already contains a loop with the default name "item"