### PR TITLE
Fix permissions as required for cron jobs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,6 @@
   file:
     path: '/etc/cron.hourly/logrotate'
     src: '/etc/cron.daily/logrotate'
-    mode: 0644
+    mode: 0700
     state: link
   when: logrotate_use_hourly_rotation | bool


### PR DESCRIPTION
The files under /etc/cron.d do not need to be executable, while the files under /etc/cron.hourly, /etc/cron.daily, /etc/cron.weekly and /etc/cron.monthly do, as they are run by run-parts command ( see: https://www.cyberciti.biz/cloud-computing/why-is-my-linux-unix-crontab-job-not-working/ )